### PR TITLE
Mirror of expensify bedrock#459

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -257,6 +257,7 @@ class BedrockServer : public SQLiteServer {
     // These control whether or not the command port is currently opened.
     bool _suppressCommandPort;
     bool _suppressCommandPortManualOverride;
+    atomic<int> _commandPortClosures;
 
     // This is a map of open listening ports to the plugin objects that created them.
     map<Port*, BedrockPlugin*> _portPluginMap;

--- a/test/clustertest/tests/ControlCommandTest.cpp
+++ b/test/clustertest/tests/ControlCommandTest.cpp
@@ -3,10 +3,11 @@
 
 struct ControlCommandTest : tpunit::TestFixture {
     ControlCommandTest()
-        : tpunit::TestFixture("ControlCommandTest",
+        : tpunit::TestFixture("ControlCommand",
                               BEFORE_CLASS(ControlCommandTest::setup),
                               AFTER_CLASS(ControlCommandTest::teardown),
-                              TEST(ControlCommandTest::testPreventAttach)) { }
+                              TEST(ControlCommandTest::testPreventAttach),
+                              TEST(ControlCommandTest::testSuppressCommandPort)) { }
 
     BedrockClusterTester* tester;
 
@@ -33,6 +34,7 @@ struct ControlCommandTest : tpunit::TestFixture {
 
         // Wait for it to detach
         sleep(3);
+
         // Try to attach
         SData attachCommand("attach");
         slave->executeWaitVerifyContent(attachCommand, "401 Attaching prevented by TestPlugin", true);
@@ -42,6 +44,80 @@ struct ControlCommandTest : tpunit::TestFixture {
         // Try to attach again, should be allowed now that the sleep in the plugin
         // has passed.
         slave->executeWaitVerifyContent(attachCommand, "204", true);
+    }
+
+    void testSuppressCommandPort()
+    {
+        // Pick a slave to test on
+        BedrockTester* slave = tester->getBedrockTester(1);
+
+        // The three commands we'll need for this test
+        SData suppress("SuppressCommandPort");
+        SData clear("ClearCommandPort");
+        SData status("Status");
+
+        // Basic case, open then close it.
+        slave->executeWaitVerifyContent(suppress, "200", true);
+        slave->executeWaitVerifyContent(clear, "200", true);
+
+        // Failure case 1, more suppressions than clears
+        slave->executeWaitVerifyContent(suppress, "200", true);
+        slave->executeWaitVerifyContent(suppress, "200", true);
+        slave->executeWaitVerifyContent(clear, "201", true);
+
+        // Ensure the port is actually closed.
+        slave->executeWaitVerifyContent(status, "002");
+
+        // Send one more clear to get the counter back to 0
+        slave->executeWaitVerifyContent(clear, "200", true);
+
+        // Ensure the port was reopened
+        int count = 0;
+        bool success = false;
+        while (count++ < 50) {
+            try {
+                string response = slave->executeWaitVerifyContent(status);
+                STable json = SParseJSONObject(response);
+                if (json["state"] == "SLAVING") {
+                    success = true;
+                    break;
+                }
+            } catch (const SException& e) {
+                // just try again
+            }
+
+            // Give it another second...
+            sleep(1);
+        }
+
+        ASSERT_TRUE(success);
+
+        // Failure case 2, more clears than suppressions
+        slave->executeWaitVerifyContent(suppress, "200", true);
+        slave->executeWaitVerifyContent(clear, "200", true);
+        slave->executeWaitVerifyContent(clear, "200", true);
+
+        // Ensure the port is actually opened, and counter didn't go below 0
+        count = 0;
+        success = false;
+        while (count++ < 50) {
+            try {
+                string response = slave->executeWaitVerifyContent(status);
+                STable json = SParseJSONObject(response);
+                if (json["state"] == "SLAVING") {
+                    ASSERT_EQUAL(json["CommandPortClosures"], "0");
+                    success = true;
+                    break;
+                }
+            } catch (const SException& e) {
+                // just try again
+            }
+
+            // Give it another second...
+            sleep(1);
+        }
+
+        ASSERT_TRUE(success);
     }
 
 } __ControlCommandTest;

--- a/test/clustertest/tests/MasteringTest.cpp
+++ b/test/clustertest/tests/MasteringTest.cpp
@@ -60,12 +60,16 @@ struct MasteringTest : tpunit::TestFixture {
         int count = 0;
         bool success = false;
         while (count++ < 50) {
-            SData cmd("Status");
-            string response = newMaster->executeWaitVerifyContent(cmd);
-            STable json = SParseJSONObject(response);
-            if (json["state"] == "MASTERING") {
-                success = true;
-                break;
+            try {
+                SData cmd("Status");
+                string response = newMaster->executeWaitVerifyContent(cmd);
+                STable json = SParseJSONObject(response);
+                if (json["state"] == "MASTERING") {
+                    success = true;
+                    break;
+                }
+            } catch (const SException& e) {
+                    // just try again
             }
 
             // Give it another second...
@@ -116,8 +120,8 @@ struct MasteringTest : tpunit::TestFixture {
             STable json1 = SParseJSONObject(responses[1]);
             STable json2 = SParseJSONObject(responses[2]);
 
-            if (json0["state"] == "MASTERING" && 
-                json1["state"] == "SLAVING" && 
+            if (json0["state"] == "MASTERING" &&
+                json1["state"] == "SLAVING" &&
                 json2["state"] == "SLAVING") {
 
                 break;


### PR DESCRIPTION
Mirror of expensify bedrock#459
tylerkaraszewski please review. With this change, callers will only be able to reopen the command port if they are the last caller to ask for it to be opened. This means that if the port is already closed when you get to it, unless the original caller that closed it has also tried to reopen, you will not be able to reopen it. I also added some more information to the status output so that we can check on how many callers have asked to close the port, and whether or not the port is currently opened or closed.

Resolves https://github.com/Expensify/Expensify/issues/78929

# Tests
Added new automated testing.

