### PR TITLE
Mirror of expensify bedrock#460

### DIFF
--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -89,19 +89,11 @@ list<string> BedrockCommandQueue::getRequestMethodLines() {
     return returnVal;
 }
 
-void BedrockCommandQueue::push(BedrockCommand&& item) {
+void BedrockCommandQueue::push(BedrockCommand&& item, bool useCurrentTime) {
     SAUTOLOCK(_queueMutex);
     auto& queue = _commandQueue[item.priority];
     item.startTiming(BedrockCommand::QUEUE_WORKER);
-    queue.emplace(item.request.calcU64("commandExecuteTime"), move(item));
-    _queueCondition.notify_one();
-}
-
-void BedrockCommandQueue::requeue(BedrockCommand&& item) {
-    SAUTOLOCK(_queueMutex);
-    auto& queue = _commandQueue[item.priority];
-    item.startTiming(BedrockCommand::QUEUE_WORKER);
-    queue.emplace(STimeNow(), move(item));
+    queue.emplace(useCurrentTime ? STimeNow() : item.request.calcU64("commandExecuteTime"), move(item));
     _queueCondition.notify_one();
 }
 

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -97,6 +97,14 @@ void BedrockCommandQueue::push(BedrockCommand&& item) {
     _queueCondition.notify_one();
 }
 
+void BedrockCommandQueue::requeue(BedrockCommand&& item) {
+    SAUTOLOCK(_queueMutex);
+    auto& queue = _commandQueue[item.priority];
+    item.startTiming(BedrockCommand::QUEUE_WORKER);
+    queue.emplace(STimeNow(), move(item));
+    _queueCondition.notify_one();
+}
+
 // This function currently never gets called. It's actually completely untested, so if you ever make any changes that
 // cause it to actually get called, you'll want to do that testing.
 bool BedrockCommandQueue::removeByID(const string& id) {

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -32,7 +32,7 @@ class BedrockCommandQueue {
 
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
     // useCurrentTime will schedule the command for now, instead of for when it was originally created. This is useful
-    // for res-scheduling conflciting commands without pushing them to the front of the queue.
+    // for re-scheduling conflicting commands without pushing them to the front of the queue.
     void push(BedrockCommand&& item, bool useCurrentTime = false);
 
     // Looks for a command with the given ID and removes it.

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -31,10 +31,9 @@ class BedrockCommandQueue {
     list<string> getRequestMethodLines();
 
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
-    void push(BedrockCommand&& item);
-
-    // Like push, but assumes we want to use the current time rather than the original time for scheduling.
-    void requeue(BedrockCommand&& item);
+    // useCurrentTime will schedule the command for now, instead of for when it was originally created. This is useful
+    // for res-scheduling conflciting commands without pushing them to the front of the queue.
+    void push(BedrockCommand&& item, bool useCurrentTime = false);
 
     // Looks for a command with the given ID and removes it.
     // This will inspect every command in the case the command does not exist.

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -33,6 +33,9 @@ class BedrockCommandQueue {
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
     void push(BedrockCommand&& item);
 
+    // Like push, but assumes we want to use the current time rather than the original time for scheduling.
+    void requeue(BedrockCommand&& item);
+
     // Looks for a command with the given ID and removes it.
     // This will inspect every command in the case the command does not exist.
     bool removeByID(const string& id);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -891,7 +891,7 @@ void BedrockServer::worker(SData& args,
             } else if (command.processCount < server._maxConflictRetries.load()) {
                 SINFO("requeueing command " << command.request.methodLine << " in main queue with "
                       << server._commandQueue.size() << " commands.");
-                server._commandQueue.requeue(move(command));
+                server._commandQueue.push(move(command), true);
             } else {
                 BedrockConflictMetrics::recordConflict(command.request.methodLine);
                 SINFO("[performance] Max retries hit in worker, forwarding command " << command.request.methodLine


### PR DESCRIPTION
Mirror of expensify bedrock#460
quinthar coleaeason 

[HOLD] Hold for high risk Wednesday.

This was discussed here: https://github.com/Expensify/Expensify/issues/70743
and here: https://github.com/Expensify/Expensify/issues/74132

This re-queues commands in the main command queue after they've conflicted. The idea is to re-order a large command list so that conflicting commands are less likely to run in the same set of commands that caused them to conflict in the first place.

We also add a `requeue` method to `BedrockCommandQueue` that schedules commands at the current time instead of at the original time they were scheduled, which keeps them from being bumped back to the front of the queue.

View with whitespace ignored. The change is really quite small, but marked for a high risk Wednesday deploy due to the unknowns around its performance implications (but I also expect no difference except under high load).
