### PR TITLE
Mirror of expensify bedrock#524

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -332,7 +332,7 @@ class BedrockServer : public SQLiteServer {
     shared_ptr<SQLiteNode> _syncNode;
 
     // Because status will access internal sync node data, we lock in both places that will access the pointer above.
-    recursive_mutex _syncMutex;
+    recursive_timed_mutex _syncMutex;
 
     // Functions for checking for and responding to status and control commands.
     bool _isStatusCommand(BedrockCommand& command);


### PR DESCRIPTION
Mirror of expensify bedrock#524
cc <at>flodnv 

Fixes: https://github.com/Expensify/Expensify/issues/90495 By using a timed mutex and only waiting 10ms until giving up. If we can't acquire the mutex, we will return `"syncNodeBlocked":true` in the response. We saw this issue when we caused the sync thread to block by trying to rebuild indexes - Status commands would not return.

Tested by adding `sleep` to sync thread and sending status commands:

Non-blocked response:
```
200 OK
nodeName: auth
totalTime: 110
unaccountedTime: 110
Content-Length: 481

{"CommitCount":466,"crashCommands":0,"escalatedCommandList":[],"host":"0.0.0.0:4445","isMaster":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"peerList":[],"plugins":[{"name":"Auth","version":"64e9d063ad2a1f95e07b4f252ccabbfdb7c2a41b"},{"name":"DB"}],"priority":200,"queuedCommandList":[],"state":"MASTERING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"09188cb6394ec3bf1c3e5425f11c2563abb08f3f:Auth_64e9d063ad2a1f95e07b4f252ccabbfdb7c2a41b"}
```

Response from blocked command:
```
200 OK
nodeName: auth
totalTime: 43751
unaccountedTime: 43751
Content-Length: 446

{"crashCommands":0,"escalatedCommandList":[],"host":"0.0.0.0:4445","isMaster":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"peerList":[],"plugins":[{"name":"Auth","version":"64e9d063ad2a1f95e07b4f252ccabbfdb7c2a41b"},{"name":"DB"}],"queuedCommandList":[],"state":"MASTERING","syncNodeBlocked":true,"syncThreadQueuedCommandList":[],"version":"09188cb6394ec3bf1c3e5425f11c2563abb08f3f:Auth_64e9d063ad2a1f95e07b4f252ccabbfdb7c2a41b"}
```

