### PR TITLE
Mirror of expensify bedrock#477

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -171,7 +171,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_httpsSend(const string& url, const S
     }
 
     // If this is going to be an https transaction, create a certificate and give it to the socket.
-    SX509* x509 = SStartsWith(url, "https://") ? SX509Open(_pem, _srvCrt, _caCrt) : nullptr;
+    SX509* x509 = SStartsWith(url, "https://") ? SX509Open(_pem, _srvCrt, _caCrt, true, nullptr) : nullptr;
     Socket* s = openSocket(host, x509);
     if (!s) {
         return _createErrorTransaction();

--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -17,14 +17,18 @@ SSSLState::~SSSLState() {
 }
 
 // --------------------------------------------------------------------------
-SSSLState* SSSLOpen(int s, SX509* x509) {
+SSSLState* SSSLOpen(int s, SX509* x509, bool server) {
     // Initialize the SSL state
     SASSERT(s >= 0);
     SSSLState* state = new SSSLState;
     state->s = s;
 
     mbedtls_ctr_drbg_seed(&state->ctr_drbg, mbedtls_entropy_func, &state->ec, 0, 0);
-    mbedtls_ssl_config_defaults(&state->conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM, 0);
+    if(server) {
+        mbedtls_ssl_config_defaults(&state->conf, MBEDTLS_SSL_IS_SERVER, MBEDTLS_SSL_TRANSPORT_STREAM, 0);
+    } else {
+        mbedtls_ssl_config_defaults(&state->conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM, 0);
+    }
 
     mbedtls_ssl_setup(&state->ssl, &state->conf);
 

--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -41,7 +41,7 @@ SSSLState* SSSLOpen(int s, SX509* x509, bool server) {
     mbedtls_ssl_config_init( &state->conf );
 
         mbedtls_ssl_conf_dbg(&state->conf, MBEDTLS_DEBUG, NULL);
-    mbedtls_debug_set_threshold(1);
+    mbedtls_debug_set_threshold(4);
 
 
     mbedtls_entropy_init( &state->ec );

--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -40,8 +40,8 @@ SSSLState* SSSLOpen(int s, SX509* x509, bool server) {
     mbedtls_ssl_init( &state->ssl );
     mbedtls_ssl_config_init( &state->conf );
 
-        mbedtls_ssl_conf_dbg(&state->conf, MBEDTLS_DEBUG, NULL);
-    mbedtls_debug_set_threshold(4);
+    mbedtls_ssl_conf_dbg(&state->conf, MBEDTLS_DEBUG, NULL);
+    mbedtls_debug_set_threshold(2);
 
 
     mbedtls_entropy_init( &state->ec );
@@ -85,7 +85,7 @@ SSSLState* SSSLOpen(int s, SX509* x509, bool server) {
 // --------------------------------------------------------------------------
 int SSSLSend(SSSLState* sslState, const char* buffer, int length) {
     // Send as much as possible and report what happened
-    SDEBUG("SSSLSend Main Func state " << sslState << " buffer " << buffer);
+    SDEBUG("SSSLSend Main Func state " << sslState << " buffer " << buffer << " length " << length);
     //SASSERT(sslState && buffer);
     const int numSent = mbedtls_ssl_write(&sslState->ssl, (unsigned char*)buffer, length);
     if (numSent > 0) {
@@ -216,7 +216,7 @@ bool SSSLSendConsume(SSSLState* ssl, string& sendBuffer) {
 // --------------------------------------------------------------------------
 bool SSSLSendAll(SSSLState* ssl, const string& buffer) {
     // Keep sending until there is an error or we're done
-    SASSERT(ssl);
+    //SASSERT(ssl);
     int totalSent = 0;
     while (totalSent < (int)buffer.size()) {
         int numSent = SSSLSend(ssl, &buffer[totalSent], (int)buffer.size() - totalSent);

--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -41,7 +41,7 @@ SSSLState* SSSLOpen(int s, SX509* x509, bool server) {
     mbedtls_ssl_config_init( &state->conf );
 
     mbedtls_ssl_conf_dbg(&state->conf, MBEDTLS_DEBUG, NULL);
-    mbedtls_debug_set_threshold(2);
+    mbedtls_debug_set_threshold(3);
 
 
     mbedtls_entropy_init( &state->ec );

--- a/libstuff/SSSLState.h
+++ b/libstuff/SSSLState.h
@@ -2,6 +2,7 @@
 #include <mbedtls/ssl.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
+#include <mbedtls/net.h>
 
 struct SSSLState {
     // Attributes
@@ -10,6 +11,8 @@ struct SSSLState {
     mbedtls_ctr_drbg_context ctr_drbg;
     mbedtls_ssl_config conf;
     mbedtls_ssl_context ssl;
+    // ctx is going to be a copy of s above.
+    mbedtls_net_context ctx;
 
     SSSLState();
     ~SSSLState();
@@ -17,12 +20,17 @@ struct SSSLState {
 
 // SSL helpers
 extern SSSLState* SSSLOpen(int s, SX509* x509);
+extern SSSLState* SSSLOpen(int s, SX509* x509, bool server);
 extern int SSSLSend(SSSLState* ssl, const char* buffer, int length);
 extern int SSSLSend(SSSLState* ssl, const string& buffer);
 extern bool SSSLSendConsume(SSSLState* ssl, string& sendBuffer);
 extern bool SSSLSendAll(SSSLState* ssl, const string& buffer);
 extern int SSSLRecv(SSSLState* ssl, char* buffer, int length);
 extern bool SSSLRecvAppend(SSSLState* ssl, string& recvBuffer);
+string SSSLError(int val);
+void MBEDTLS_DEBUG( void *ctx, int level,
+                      const char *file, int line,
+                      const char *str );
 extern string SSSLGetState(SSSLState* ssl);
 extern void SSSLShutdown(SSSLState* ssl);
 extern void SSSLClose(SSSLState* ssl);

--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -258,8 +258,10 @@ bool STCPManager::Socket::send() {
     // Send data
     bool result = false;
     if (ssl) {
+        SDEBUG("MB socket send SSL");
         result = SSSLSendConsume(ssl, sendBuffer);
     } else if (s > 0) {
+        SDEBUG("MB socket send non-SSL");
         result = S_sendconsume(s, sendBuffer);
     }
     lastSendTime = STimeNow();
@@ -302,8 +304,10 @@ bool STCPManager::Socket::recv() {
     bool result = false;
     const size_t oldSize = recvBuffer.size();
     if (ssl) {
+        SDEBUG("MB SSL RECV");
         result = SSSLRecvAppend(ssl, recvBuffer);
     } else if (s > 0) {
+        SDEBUG("MB NON-SSL RECV");
         result = S_recvappend(s, recvBuffer);
     }
 

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -19,6 +19,7 @@ struct STCPManager {
         uint64_t lastSendTime;
         uint64_t lastRecvTime;
         SSSLState* ssl;
+        bool useSSL; // force send and recv to use mbedTLS instead of net::
         void* data;
         bool send();
         bool send(const string& buffer);

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -139,6 +139,20 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         }
     }
 
+    SDEBUG("MY PEERS");
+    for (Peer* peer : peerList) {
+        if(peer->s) {
+            if(peer->s->ssl) {
+                SDEBUG("Peer " << peer->name << " in SSL state " << SSSLGetState(peer->s->ssl));
+            } else {
+                SDEBUG("Peer " << peer->name << " in Non-SSL state " << peer->s->state.load());
+            }
+        } else {
+            SDEBUG("Peer " << peer->name << " disconnected. " );
+        }
+
+    }
+
     // Try to establish connections with peers and process messages
     for (Peer* peer : peerList) {
         // See if we're connected

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -230,7 +230,7 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 // Done; clean up and try to reconnect
                 uint64_t delay;
                 if(peer->s->ssl) {
-                    delay = SRandom::rand64() % (STIME_US_PER_S * 5) + 5000;
+                    delay = SRandom::rand64() % (STIME_US_PER_S * 5);
                 } else {
                     delay = SRandom::rand64() % (STIME_US_PER_S * 5);
                 }
@@ -312,7 +312,7 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                                 ret = -1;
                                 SDEBUG("XXXXXXXXXXXXXXXX MB Client Handshake ABORTING.");
                             }
-                        } while(ret != 0);
+                        } while(ret > 0);
 
                         //SDEBUG("MB NON LOOP HANDSHAKE " << ret);
                         //ret = mbedtls_ssl_handshake(&peer->ssl->ssl);
@@ -364,6 +364,7 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                     peer->nextReconnect = STimeNow() + STIME_US_PER_M;
                 }
             } else {
+                SDEBUG("MB Waiting to reconnect" << STimeNow() << " not yet " << peer->nextReconnect << "(" << peer->nextReconnect - STimeNow() << " ms remaining)");
                 // Waiting to reconnect -- notify the caller
                 nextActivity = min(nextActivity, peer->nextReconnect);
             }

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -44,6 +44,7 @@ struct STCPNode : public STCPServer {
 
       private:
         Socket* s;
+        SSSLState* ssl;
         recursive_mutex socketMutex;
     };
 

--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -61,6 +61,33 @@ STCPManager::Socket* STCPServer::acceptSocket(Port*& portOut) {
             // Received a socket, wrap
             SDEBUG("Accepting socket from '" << addr << "' on port '" << port.host << "'");
             socket = new Socket(s, Socket::CONNECTED);
+
+
+            // SSL?
+            SDEBUG("MB SERVER ACCEPTSOCKET " << socket->state.load() << " " << SToStr(socket->addr));
+
+            SX509* x509;
+
+            x509 = SX509Open();
+
+            socket->ssl = SSSLOpen(s, x509, true);
+            SDEBUG("MB SSL object for peer client created"); 
+            // SERVER HELLO?
+            
+            int ret = 0;
+            do {
+                ret = mbedtls_ssl_handshake(&socket->ssl->ssl);
+                SDEBUG("MB Server SSL Handshake " << ret << " : " << SSSLError(ret));
+                sleep(1);
+            } while(ret != 0);
+            
+            //SDEBUG("MB NON-LOOP SERVER Handshake");
+            //int ret = mbedtls_ssl_handshake(&socket->ssl->ssl);
+            
+
+            SDEBUG("XXXXXXXXXXXXXXXXXXXXXXXXXX MB Server Handshake Completed!" << ret);
+            socket->useSSL = true;
+
             socket->addr = addr;
             socketList.push_back(socket);
 

--- a/libstuff/STCPServer.h
+++ b/libstuff/STCPServer.h
@@ -8,6 +8,7 @@ struct STCPServer : public STCPManager {
         // Attributes
         int s;
         string host;
+        bool isHost;
     };
 
     // Listens on a given port and accepts sockets, and shuts them down

--- a/libstuff/SX509.cpp
+++ b/libstuff/SX509.cpp
@@ -4,31 +4,64 @@
 // --------------------------------------------------------------------------
 SX509* SX509Open() {
     // Initialize with defaults
-    return SX509Open("", "", "");
+    return SX509Open("", "", "", true, "");
+}
+
+SX509* SX509Open(const string& pem, const string& srvCrt, const string& caCrt) {
+    // initialize a default server state
+    return SX509Open(pem, srvCrt, caCrt, true, "");
+}
+
+// open an SSL client cert chain using CAS/PEM
+SX509* SX509Open(const string& casCrt) {
+    // initialize a default client state
+    return SX509Open(nullptr, nullptr, nullptr, false, casCrt);
 }
 
 // --------------------------------------------------------------------------
-SX509* SX509Open(const string& pem, const string& srvCrt, const string& caCrt) {
-    // Use either the supplied credentials, or defaults for testing
-    const char* pemPtr = (pem.empty() ? mbedtls_test_srv_key : pem.c_str());
-    const char* srvCrtPtr = (srvCrt.empty() ? mbedtls_test_srv_crt : srvCrt.c_str());
-    const char* caCrtPtr = (caCrt.empty() ? mbedtls_test_ca_crt : caCrt.c_str());
+SX509* SX509Open(const string& pem, const string& srvCrt, const string& caCrt, bool server, const string& casCrt) {
+    const char* pemPtr;
+    const char* srvCrtPtr;
+    const char* caCrtPtr;
+    const char* casCrtPtr;
+
+    SX509* x509 = new SX509;
+
+    // The server bool chooses between client and server defaults.
+    if(server) {
+        // Use either the supplied credentials, or defaults for testing
+        pemPtr = (pem.empty() ? mbedtls_test_srv_key : pem.c_str());
+        srvCrtPtr = (srvCrt.empty() ? mbedtls_test_srv_crt : srvCrt.c_str());
+        caCrtPtr = (caCrt.empty() ? mbedtls_test_ca_crt : caCrt.c_str());
+
+        mbedtls_pk_init(&(x509->pk));
+    } else {
+        casCrtPtr = (casCrt.empty() ? mbedtls_test_cas_pem : casCrt.c_str());
+    }
+
 
     // Just create a fake certificate from the PolarSSL defaults
-    SX509* x509 = new SX509;
-    mbedtls_x509_crt_init(&(x509->srvcert));
-    mbedtls_pk_init(&(x509->pk));
+    
+    mbedtls_x509_crt_init(&(x509->cert));
+    
     try {
-        // Load and initialize this key
-        if (mbedtls_pk_parse_key(&x509->pk, (unsigned char*)pemPtr, (int)strlen(pemPtr) + 1, NULL, 0)) {
-            STHROW("parsing key");
+        if(server) {
+            // Load and initialize this key
+            if (mbedtls_pk_parse_key(&x509->pk, (unsigned char*)pemPtr, (int)strlen(pemPtr) + 1, NULL, 0)) {
+                STHROW("MB parsing key");
+            }
+            if (mbedtls_x509_crt_parse(&x509->cert, (unsigned char*)srvCrtPtr, (int)strlen(srvCrtPtr) + 1)) {
+                STHROW("MB parsing server certificate");
+            }
+            if (mbedtls_x509_crt_parse(&x509->cert, (unsigned char*)caCrtPtr, (int)strlen(caCrtPtr) + 1)) {
+                STHROW("MB parsing CA certificate");
+            }
+        } else {
+            if (mbedtls_x509_crt_parse(&(x509->cert), (unsigned char*)casCrtPtr, (int)strlen(casCrtPtr) + 1) ) {
+                STHROW("MB Client Parse CAS Failed");
+            }
         }
-        if (mbedtls_x509_crt_parse(&x509->srvcert, (unsigned char*)srvCrtPtr, (int)strlen(srvCrtPtr) + 1)) {
-            STHROW("parsing server certificate");
-        }
-        if (mbedtls_x509_crt_parse(&x509->srvcert, (unsigned char*)caCrtPtr, (int)strlen(caCrtPtr) + 1)) {
-            STHROW("parsing CA certificate");
-        }
+        
         return x509;
     } catch (const SException& e) {
         // Failed
@@ -41,7 +74,7 @@ SX509* SX509Open(const string& pem, const string& srvCrt, const string& caCrt) {
 // --------------------------------------------------------------------------
 void SX509Close(SX509* x509) {
     // Clean up
-    mbedtls_x509_crt_free(&x509->srvcert);
+    mbedtls_x509_crt_free(&x509->cert);
     mbedtls_pk_free(&x509->pk);
     delete x509;
 }

--- a/libstuff/SX509.h
+++ b/libstuff/SX509.h
@@ -5,11 +5,17 @@
 // Wraps a X509 Cert
 struct SX509 {
     // Attributes
-    mbedtls_x509_crt srvcert;
+    mbedtls_x509_crt cert;
     mbedtls_pk_context pk;
 };
 
 // X509 Certificates
 extern SX509* SX509Open();
+
 extern SX509* SX509Open(const string& pem, const string& srvCrt, const string& caCrt);
+
+extern SX509* SX509Open(const string& casCrt);
+
+extern SX509* SX509Open(const string& pem, const string& srvCrt, const string& caCrt, bool server, const string& casCrt);
+
 extern void SX509Close(SX509* x509);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1884,7 +1884,10 @@ void SQLiteNode::_sendToPeer(Peer* peer, const SData& message) {
     SData messageCopy = message;
     messageCopy["CommitCount"] = to_string(_db.getCommitCount());
     messageCopy["Hash"] = _db.getCommittedHash();
-    peer->s->send(messageCopy.serialize());
+    if(peer->s) {
+        peer->s->send(messageCopy.serialize());
+    }
+    
 }
 
 void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {


### PR DESCRIPTION
Mirror of expensify bedrock#477
This is a big change, so I am making a WIP tracking PR so that I can talk to myself and keep things organized.

This has evolved into a functional proof of concept. After review with tyler, this can progress to a proper implementation. There are a ton of edge cases that the POC did not handle. 

This will be an ever-changing list. I also expect to be talking to myself in here a lot. The real PR may be a different one if it gets too noisy/distracting in here.

TO BE IMPLEMENTED

TLS Certificates

- [ ] Allow custom certificates at the binary arguments level.
- [ ] Allow custom CA chains to be loaded at the binary arguments level.
- [ ] Allow TLS to be optional (ie, 3 levels of enforcement: none (today's mode), either, TLS-only.
- [ ] Allow mixed TLS compliance? (Nodes A<->C use TLS, A<->B does not) 
- [ ] Create new Cluster tests for Certificate validations. Attempt to capture each handshake step from both client and server side.
- [ ] Create new Cluster tests for handshake failures
- [ ] Create new Cluster tests for certificate revocation
- [ ] Create new Cluster tests for mixed TLS case, if allowed.

Node Client

- [ ] Handle each of the 12-15 handshake states, and allow graceful failure/retry of a node handshake
- [ ] (Optional, likely a defer item) Attempt to convert the blocking socket to non-blocking.
- [ ] (Optional, likely a defer item) Attempt to implement SSL_SESSION_RESET for quicker desync/resync
- [ ] Support periodic re-checks of server certificate to handle in-flight certificate revocation

Node Server

- [ ] Handle each of the 12-15 handshake states, and allow graceful failure with proper logging of what went wrong/reasons for rejection.
- [ ] Support periodic re-checks of server certificate to handle in-flight certificate revocation
- [ ] Attempt to convert the current blocking socket to non-blocking.

General Protocol Work

- [ ] Verify graceful handling of SSL_MAX_FRAGMENT_LENGTH.
- [ ] Limit acceptable ciphers to the acceptable/PCI compliant strong ciphers.
- [ ] Add DNS lookup/reverse lookup to prevent spoofed hostname/certificate pair

Fault Tolerance

- [ ] Verify that no data corruption occurs when a node MASTERS or when QUORUM commands are executed.
- [ ] Verify that there are no timing/lag concerns with the added overhead of SSL handshaking when nodes disconnect/reconnect/initialize. Certain hardcoded wait states may need tuned.

Performance

- [ ] Determine if hardware-accelerated ciphers add a meaningful performance improvement

