### PR TITLE
Mirror of expensify bedrock#532

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -762,6 +762,12 @@ void BedrockServer::worker(SData& args,
                 SWARN("Found " << (command.complete ? "" : "in") << "complete " << "command "
                       << command.request.methodLine << " from peer, but not mastering. Too late for it, discarding.");
                 server._commandsInProgress--;
+
+                // If the command was processed, tell the plugin we couldn't send the response.
+                if (command.processedBy) {
+                    command.processedBy->handleFailedReply(command);
+                }
+
                 continue;
             }
 


### PR DESCRIPTION
Mirror of expensify bedrock#532
This allows for the same automatic re-queuing of `GetJob` and `GetJobs` commands that we added when the client has disconnected, but in the case where the server stopped mastering while we had the command queued.
